### PR TITLE
Fix services.web.ports is invalid: Port ranges don't match in length

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
     volumes:
       - ./:/app/
     ports:
-      - "${DOCKER_HTTP_PORT}:9501"
+      - "${DOCKER_HTTP_PORT:-9501}:9501"
     environment:
       ENTRY_POINT_FILE: /app/http/server.php


### PR DESCRIPTION
```
t@xps13 ~/> sudo docker-compose up
WARNING: The DOCKER_API_PORT variable is not set. Defaulting to a blank string.
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.web.ports is invalid: Port ranges don't match in length
```

Fixed this by adding a default